### PR TITLE
cs225 initial update

### DIFF
--- a/_includes/cs225.md
+++ b/_includes/cs225.md
@@ -1,6 +1,12 @@
-<!---
-Feel free to change this link if there is something more appropriate.
-Do not change the anchor name.
+<!--
+7/6/2018 -- waf@illinois.edu
+- Initial update.
 -->
 
-### <a name="CS225" class="anchor"></a>[CS 225: Data Structures](https://courses.engr.illinois.edu/cs225/sp2018/)
+## <a name="CS225" class="anchor"></a>[CS 225: Data Structures](https://courses.engr.illinois.edu/cs225/)
+
+* **Format**: A combination of theory-based and programming-based questions.  Details TBA.
+<!--- -->
+* **Length**: 3 hours
+<!--- -->
+* **More Information**: Sample exams can be viewed on the [Exams page of the CS 225 website](https://courses.engr.illinois.edu/cs225/sp2018//exams/#practice-exams).


### PR DESCRIPTION
Initial update with known CS 225 information.

I'm excited to move CS 225 to CBTF proficiency exams, though I don't think we'll be ready in Fall 2018.  We'll finalize paper vs. CBTF by early August, but the topic coverage will be the same either way.